### PR TITLE
Fix double-socket-close in ServerConnection

### DIFF
--- a/src/base/ServerConnection.cpp
+++ b/src/base/ServerConnection.cpp
@@ -127,14 +127,16 @@ void ServerConnection::clientHandler(int clientSocketFd) {
     LOG(WARNING) << "Error handling new client: " << err.what();
     if (createdClientConnection) {
       destroyPartialConnection(clientId);
+    } else {
+      socketHandler->close(clientSocketFd);
     }
-    socketHandler->close(clientSocketFd);
   } catch (const std::exception& e) {
     LOG(ERROR) << "Got an unexpected error handling new client: " << e.what();
     if (createdClientConnection) {
       destroyPartialConnection(clientId);
+    } else {
+      socketHandler->close(clientSocketFd);
     }
-    socketHandler->close(clientSocketFd);
   }
 }
 

--- a/test/ServerFifoPathTest.cpp
+++ b/test/ServerFifoPathTest.cpp
@@ -25,6 +25,8 @@ struct FileInfo {
   }
 };
 
+bool IsRoot() { return ::geteuid() == 0; }
+
 int RemoveDirectory(const char* path) {
   // Use posix file tree walk to traverse the directory and remove the contents.
   return nftw(
@@ -101,6 +103,11 @@ class TestEnvironment {
 }  // namespace
 
 TEST_CASE("Creation", "[ServerFifoPath]") {
+  if (IsRoot()) {
+    WARN("Test running as root: Skipping test");
+    return;
+  }
+
   TestEnvironment env;
 
   const string homeDir = env.createTempDir();
@@ -206,6 +213,11 @@ TEST_CASE("Creation", "[ServerFifoPath]") {
 }
 
 TEST_CASE("Override", "[ServerFifoPath]") {
+  if (IsRoot()) {
+    WARN("Test running as root: Skipping test");
+    return;
+  }
+
   TestEnvironment env;
 
   const string homeDir = env.createTempDir();


### PR DESCRIPTION
When this double-close occurs, an STFATAL is hit in UnixSocketHandler
since the socket is already closed.

To fix, if `destroyPartialConnection` is called don't call `close`,
since `destroyPartialConnection` already closes the socket.